### PR TITLE
Add CodebaseGrepTool for regex searching in codebase

### DIFF
--- a/grep.py
+++ b/grep.py
@@ -1,35 +1,29 @@
 import os
 import re
-from pydantic import BaseModel, Field
-from langchain_core.tools import BaseTool
-class CodebaseGrepToolInput(BaseModel):
-    search_directory: str = Field(description="The directory to search for the pattern.")
-    pattern: str = Field(description="The regex pattern to search for.")
-    file_extension: Optional[str] = Field(description="The file extension to search for (optional).")
-    case_sensitive: bool = Field(default=False, description="Whether the search should be case sensitive.")
-class CodebaseGrepTool(BaseTool):
-    name: str = "codebase_grep"
-    description: str = "Search a given directory for a regex pattern using Python's re and os modules."
-    args_schema: type[BaseModel] = CodebaseGrepToolInput
 
-    def _run(self, search_directory: str, pattern: str, file_extension: Optional[str] = None, case_sensitive: bool = False) -> str:
-        try:
-            ignored_directories = ['.git', 'node_modules', 'venv', '.venv', '__pycache__']
-            matches = []
-            for root, dirs, files in os.walk(search_directory):
-                for file in files:
-                    if file_extension and not file.endswith(file_extension):
-                        continue
-                    file_path = os.path.join(root, file)
-                    try:
-                        with open(file_path, 'r', encoding='utf-8') as f:
-                            content = f.read()
-                            if re.search(pattern, content, re.MULTILINE | (not case_sensitive and re.IGNORECASE)):
-                                matches.append((file_path, content))
-                    except UnicodeDecodeError:
-                        pass
-                    if len(matches) >= 100:
-                        break
-            return str(matches)
-        except Exception as e:
-            return f"Error executing codebase_grep: {str(e)}"
+def codebase_grep(search_directory: str, pattern: str, file_extension: str = None, case_sensitive: bool = False) -> list:
+    matches = []
+    flags = 0 if case_sensitive else re.IGNORECASE
+    
+    for root, dirs, files in os.walk(search_directory):
+        # Skip ignored directories
+        if any(ignore_dir in dirs for ignore_dir in ['.git', 'node_modules', 'venv', '.venv', '__pycache__']):
+            dirs[:] = [d for d in dirs if d not in ['.git', 'node_modules', 'venv', '.venv', '__pycache__']]
+            continue
+        
+        for file in files:
+            if file_extension and not file.endswith(file_extension):
+                continue
+            
+            file_path = os.path.join(root, file)
+            try:
+                with open(file_path, 'r', encoding='utf-8') as f:
+                    content = f.read()
+                    if re.search(pattern, content, flags):
+                        matches.append(file_path)
+                        if len(matches) >= 100:
+                            return matches
+            except UnicodeDecodeError:
+                # Skip binary files
+                continue
+    return matches


### PR DESCRIPTION
This tool allows searching codebases with regex patterns, supporting file extensions, case sensitivity, and skipping binary files and common ignore directories.